### PR TITLE
fix: dont allow nonmaster to update user's authData

### DIFF
--- a/src/Adapters/Auth/mfa.js
+++ b/src/Adapters/Auth/mfa.js
@@ -108,7 +108,7 @@ class MFAAdapter extends AuthAdapter {
       });
     } else if (opts.period && typeof opts.period === 'object') {
       Object.keys(opts.period).forEach(method => {
-        if (opts.period.hasOwnProperty(method) && typeof opts.period[method] === 'number') {
+        if (typeof opts.period[method] === 'number') {
           this.period[method] = opts.period[method] ?? defaultPeriods[method] ?? 30;
         }
       });

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -504,7 +504,9 @@ RestWrite.prototype.ensureUniqueAuthDataId = async function () {
     key => this.data.authData[key] && this.data.authData[key].id
   );
 
-  if (!hasAuthDataId) { return; }
+  if (!hasAuthDataId) {
+    return;
+  }
 
   const r = await Auth.findUsersWithAuthData(this.config, this.data.authData);
   const results = this.filteredObjectsByACL(r);
@@ -547,7 +549,6 @@ RestWrite.prototype.handleAuthData = async function (authData) {
 
   // User found with provided authData
   if (results.length === 1) {
-
     this.storage.authProvider = Object.keys(authData).join(',');
 
     const { hasMutatedAuthData, mutatedAuthData } = Auth.hasMutatedAuthData(
@@ -809,7 +810,9 @@ RestWrite.prototype._validateEmail = function () {
 };
 
 RestWrite.prototype._validatePasswordPolicy = function () {
-  if (!this.config.passwordPolicy) { return Promise.resolve(); }
+  if (!this.config.passwordPolicy) {
+    return Promise.resolve();
+  }
   return this._validatePasswordRequirements().then(() => {
     return this._validatePasswordHistory();
   });
@@ -843,18 +846,20 @@ RestWrite.prototype._validatePasswordRequirements = function () {
   if (this.config.passwordPolicy.doNotAllowUsername === true) {
     if (this.data.username) {
       // username is not passed during password reset
-      if (this.data.password.indexOf(this.data.username) >= 0)
-      { return Promise.reject(new Parse.Error(Parse.Error.VALIDATION_ERROR, containsUsernameError)); }
+      if (this.data.password.indexOf(this.data.username) >= 0) {
+        return Promise.reject(new Parse.Error(Parse.Error.VALIDATION_ERROR, containsUsernameError));
+      }
     } else {
       // retrieve the User object using objectId during password reset
       return this.config.database.find('_User', { objectId: this.objectId() }).then(results => {
         if (results.length != 1) {
           throw undefined;
         }
-        if (this.data.password.indexOf(results[0].username) >= 0)
-        { return Promise.reject(
+        if (this.data.password.indexOf(results[0].username) >= 0) {
+          return Promise.reject(
             new Parse.Error(Parse.Error.VALIDATION_ERROR, containsUsernameError)
-        ); }
+          );
+        }
         return Promise.resolve();
       });
     }
@@ -878,19 +883,21 @@ RestWrite.prototype._validatePasswordHistory = function () {
         }
         const user = results[0];
         let oldPasswords = [];
-        if (user._password_history)
-        { oldPasswords = _.take(
+        if (user._password_history) {
+          oldPasswords = _.take(
             user._password_history,
             this.config.passwordPolicy.maxPasswordHistory - 1
-        ); }
+          );
+        }
         oldPasswords.push(user.password);
         const newPassword = this.data.password;
         // compare the new password hash with all old password hashes
         const promises = oldPasswords.map(function (hash) {
           return passwordCrypto.compare(newPassword, hash).then(result => {
-            if (result)
+            if (result) {
               // reject if there is a match
-            { return Promise.reject('REPEAT_PASSWORD'); }
+              return Promise.reject('REPEAT_PASSWORD');
+            }
             return Promise.resolve();
           });
         });
@@ -900,14 +907,15 @@ RestWrite.prototype._validatePasswordHistory = function () {
             return Promise.resolve();
           })
           .catch(err => {
-            if (err === 'REPEAT_PASSWORD')
+            if (err === 'REPEAT_PASSWORD') {
               // a match was found
-            { return Promise.reject(
+              return Promise.reject(
                 new Parse.Error(
                   Parse.Error.VALIDATION_ERROR,
                   `New password should not be the same as last ${this.config.passwordPolicy.maxPasswordHistory} passwords.`
                 )
-            ); }
+              );
+            }
             throw err;
           });
       });
@@ -941,10 +949,16 @@ RestWrite.prototype.createSessionTokenIfNeeded = async function () {
     // Get verification conditions which can be booleans or functions; the purpose of this async/await
     // structure is to avoid unnecessarily executing subsequent functions if previous ones fail in the
     // conditional statement below, as a developer may decide to execute expensive operations in them
-    const verifyUserEmails = async () => this.config.verifyUserEmails === true || (typeof this.config.verifyUserEmails === 'function' && await Promise.resolve(this.config.verifyUserEmails(request)) === true);
-    const preventLoginWithUnverifiedEmail = async () => this.config.preventLoginWithUnverifiedEmail === true || (typeof this.config.preventLoginWithUnverifiedEmail === 'function' && await Promise.resolve(this.config.preventLoginWithUnverifiedEmail(request)) === true);
+    const verifyUserEmails = async () =>
+      this.config.verifyUserEmails === true ||
+      (typeof this.config.verifyUserEmails === 'function' &&
+        (await Promise.resolve(this.config.verifyUserEmails(request))) === true);
+    const preventLoginWithUnverifiedEmail = async () =>
+      this.config.preventLoginWithUnverifiedEmail === true ||
+      (typeof this.config.preventLoginWithUnverifiedEmail === 'function' &&
+        (await Promise.resolve(this.config.preventLoginWithUnverifiedEmail(request))) === true);
     // If verification is required
-    if (await verifyUserEmails() && await preventLoginWithUnverifiedEmail()) {
+    if ((await verifyUserEmails()) && (await preventLoginWithUnverifiedEmail())) {
       this.storage.rejectSignup = true;
       return;
     }
@@ -1437,7 +1451,12 @@ RestWrite.prototype.runDatabaseOperation = function () {
     );
   }
   // Handle authData updates for _User class
-  if (this.className === '_User' && this.query && this.data.authData) {
+  if (
+    this.className === '_User' &&
+    this.query &&
+    this.data &&
+    Object.prototype.hasOwnProperty.call(this.data, 'authData')
+  ) {
     if (!this.auth.isMaster && !this.auth.isMaintenance) {
       // For non-master key requests, remove authData from the update
       delete this.data.authData;
@@ -1758,7 +1777,9 @@ RestWrite.prototype.buildParseObjects = function () {
         }
         let curObj = parentVal;
         for (let i = 1; i < splittedKey.length - 1; i++) {
-          if (typeof curObj[splittedKey[i]] === 'undefined') curObj[splittedKey[i]] = {};
+          if (typeof curObj[splittedKey[i]] === 'undefined') {
+            curObj[splittedKey[i]] = {};
+          }
           curObj = curObj[splittedKey[i]];
         }
         curObj[splittedKey[splittedKey.length - 1]] = data[key];

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -853,7 +853,7 @@ RestWrite.prototype._validatePasswordRequirements = function () {
         }
         if (this.data.password.indexOf(results[0].username) >= 0)
         { return Promise.reject(
-          new Parse.Error(Parse.Error.VALIDATION_ERROR, containsUsernameError)
+            new Parse.Error(Parse.Error.VALIDATION_ERROR, containsUsernameError)
         ); }
         return Promise.resolve();
       });
@@ -880,8 +880,8 @@ RestWrite.prototype._validatePasswordHistory = function () {
         let oldPasswords = [];
         if (user._password_history)
         { oldPasswords = _.take(
-          user._password_history,
-          this.config.passwordPolicy.maxPasswordHistory - 1
+            user._password_history,
+            this.config.passwordPolicy.maxPasswordHistory - 1
         ); }
         oldPasswords.push(user.password);
         const newPassword = this.data.password;
@@ -889,7 +889,7 @@ RestWrite.prototype._validatePasswordHistory = function () {
         const promises = oldPasswords.map(function (hash) {
           return passwordCrypto.compare(newPassword, hash).then(result => {
             if (result)
-            // reject if there is a match
+              // reject if there is a match
             { return Promise.reject('REPEAT_PASSWORD'); }
             return Promise.resolve();
           });
@@ -901,12 +901,12 @@ RestWrite.prototype._validatePasswordHistory = function () {
           })
           .catch(err => {
             if (err === 'REPEAT_PASSWORD')
-            // a match was found
+              // a match was found
             { return Promise.reject(
-              new Parse.Error(
-                Parse.Error.VALIDATION_ERROR,
-                `New password should not be the same as last ${this.config.passwordPolicy.maxPasswordHistory} passwords.`
-              )
+                new Parse.Error(
+                  Parse.Error.VALIDATION_ERROR,
+                  `New password should not be the same as last ${this.config.passwordPolicy.maxPasswordHistory} passwords.`
+                )
             ); }
             throw err;
           });
@@ -1435,6 +1435,18 @@ RestWrite.prototype.runDatabaseOperation = function () {
       Parse.Error.SESSION_MISSING,
       `Cannot modify user ${this.query.objectId}.`
     );
+  }
+  // Handle authData updates for _User class
+  if (this.className === '_User' && this.query && this.data.authData) {
+    if (!this.auth.isMaster && !this.auth.isMaintenance) {
+      // For non-master key requests, remove authData from the update
+      delete this.data.authData;
+      // If no other fields to update, return early
+      if (Object.keys(this.data).length === 0) {
+        this.response = { response: {} };
+        return Promise.resolve();
+      }
+    }
   }
 
   if (this.className === '_Product' && this.data.download) {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: FILL_THIS_OUT

## Approach
<!-- Describe the changes in this PR. -->

## Tasks
<!-- Delete tasks that don't apply. -->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
