### PR TITLE
fix: extended session usage using LRU cache

### DIFF
--- a/spec/Auth.spec.js
+++ b/spec/Auth.spec.js
@@ -106,6 +106,8 @@ describe('Auth', () => {
         updatedAt: updatedAt.toISOString(),
       }
     );
+    Parse.Server.cacheController.clear();
+    await new Promise(resolve => setTimeout(resolve, 1000));
     await session.fetch();
     await new Promise(resolve => setTimeout(resolve, 1000));
     await session.fetch();


### PR DESCRIPTION
…y clear memory and functions as a debounce instead of a throttle (#8683)

## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: FILL_THIS_OUT

## Approach
<!-- Describe the changes in this PR. -->

## Tasks
<!-- Delete tasks that don't apply. -->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
